### PR TITLE
Corrige linhas do jogo da velha

### DIFF
--- a/css/estilo.css
+++ b/css/estilo.css
@@ -155,7 +155,7 @@ legend {
 /* TIC-TAC-TOE */
 
 .botaoDeJogada {
-    width: 33%;
+    width: 25%;
     height: 100px;
     font-size: 30pt;
     font-family: 'Trebuchet MS';


### PR DESCRIPTION
Por algum motivo, usar 33% no width dos botões de jogada está quebrando o tabuleiro. Essa modificação corrige esse problema:

![image](https://user-images.githubusercontent.com/31022286/77343740-f543ff80-6d10-11ea-9208-4f901e5ce800.png)

Talvez tenha algum método mais elegante de resolver isso com flexbox, mas eu não manjo.